### PR TITLE
Add CI workflow for linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Lint and format balrog control
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: install uv
+      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: setup uv
+      run: uv sync
+    - name: run linter
+      run: uv run ruff check --exit-non-zero-on-fix
+    - name: run formatter
+      run: uv run ruff format --check --exit-non-zero-on-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -21,5 +21,13 @@ jobs:
       run: uv sync
     - name: run linter
       run: uv run ruff check --exit-non-zero-on-fix
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: install uv
+      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: setup uv
+      run: uv sync
     - name: run formatter
       run: uv run ruff format --check --exit-non-zero-on-format


### PR DESCRIPTION
This adds a basic CI for running a linter and a formatter. The pipeline will fail when the linter detects an issue; the same applies to the formatter. This helps to improve the code quality. Currently, both will fail, and it would be good to address these issues. If the rules are too strict, we can relax them a little.